### PR TITLE
Improve mobile touch controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,12 +23,13 @@ canvas#game { width:min(96vw, 1024px); height:auto; image-rendering: pixelated; 
 .btn:active { transform: translateY(1px); }
 
 .touch-only { position:absolute; right:10px; bottom:10px; display:none; gap:8px; }
-.dpad { width:56px; height:56px; background:#1b212c; border:1px solid #2a2f39; border-radius:8px; color:#e8ecf1; }
+.dpad { width:56px; height:56px; background:#1b212c; border:1px solid #2a2f39; border-radius:8px; color:#e8ecf1; cursor:pointer; }
+.dpad, .act { user-select:none; -webkit-user-select:none; touch-action:manipulation; }
 .dpad:active, .act:active { transform: translateY(1px); }
 .row { display:flex; gap:8px; }
 
 @media (max-width: 900px) {
-  .touch-only { display:flex; flex-direction:column; }
+  .touch-only { display:flex; flex-direction:column; align-items:center; }
 }
 
 #coords { opacity:.6; }

--- a/script.js
+++ b/script.js
@@ -85,13 +85,22 @@
    addEventListener("keyup",   (e)=>{ const k = KEYS[e.code]; if (k){ Input[k]=false; e.preventDefault(); }});
    
    // touch
-   $("#touchpad")?.addEventListener("click", (e)=>{
-     const dir = e.target.dataset.dir;
-     if (dir) { Input[dir]=true; setTimeout(()=> Input[dir]=false, 80); }
-   });
-   $("#btn-act")?.addEventListener("click", ()=>{
-     Input.act=true; setTimeout(()=> Input.act=false, 120);
-   });
+  const touchpad = $("#touchpad");
+  if (touchpad) {
+    touchpad.addEventListener("pointerdown", (e) => {
+      const dir = e.target.dataset.dir;
+      if (dir) {
+        Input[dir] = true;
+        setTimeout(() => (Input[dir] = false), 80);
+        e.preventDefault();
+      }
+    });
+  }
+  $("#btn-act")?.addEventListener("pointerdown", (e)=>{
+    Input.act = true;
+    setTimeout(() => (Input.act = false), 120);
+    e.preventDefault();
+  });
    
    /* ========= Helpers ========= */
    const clamp = (v, min, max)=> Math.max(min, Math.min(max, v));

--- a/style.css
+++ b/style.css
@@ -16,12 +16,13 @@ canvas#game { width:min(96vw, 1024px); height:auto; image-rendering: pixelated; 
 .btn:active { transform: translateY(1px); }
 
 .touch-only { position:absolute; right:10px; bottom:10px; display:none; gap:8px; }
-.dpad { width:56px; height:56px; background:#1b212c; border:1px solid #2a2f39; border-radius:8px; }
+.dpad { width:56px; height:56px; background:#1b212c; border:1px solid #2a2f39; border-radius:8px; cursor:pointer; color:#e8ecf1; }
+.dpad, .act { user-select:none; -webkit-user-select:none; touch-action:manipulation; }
 .dpad:active, .act:active { transform: translateY(1px); }
 .row { display:flex; gap:8px; }
 
 @media (max-width: 900px) {
-  .touch-only { display:flex; flex-direction:column; }
+  .touch-only { display:flex; flex-direction:column; align-items:center; }
 }
 
 #coords { opacity:.6; }


### PR DESCRIPTION
## Summary
- Center mobile touchpad buttons for a uniform D-pad layout
- Prevent double taps and text selection by using pointer events and disabling user select

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_689c5ca0dee88330be0fd64268f49810