### PR TITLE
Add mobile touch controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,16 @@
     .pill{padding:.2rem .5rem;background:#111;border:1px solid #333;border-radius:6px}
     .btn{color:#eee;text-decoration:none;border:1px solid #333;padding:.2rem .6rem;border-radius:6px;background:#111}
     .hint{opacity:.8}
+    /* mobile touch controls */
+    #mobile-controls{position:fixed;bottom:20px;left:20px;display:none;gap:40px;user-select:none;}
+    #mobile-controls button{width:48px;height:48px;font-size:18px;background:#111;border:1px solid #333;color:#eee;border-radius:6px;}
+    #mobile-controls .dpad{display:grid;grid-template:repeat(3,48px)/repeat(3,48px);gap:4px;}
+    #mobile-controls .dpad .up{grid-column:2;grid-row:1;}
+    #mobile-controls .dpad .left{grid-column:1;grid-row:2;}
+    #mobile-controls .dpad .down{grid-column:2;grid-row:3;}
+    #mobile-controls .dpad .right{grid-column:3;grid-row:2;}
+    #mobile-controls .actions{display:flex;flex-direction:column;gap:8px;}
+    @media (max-width:800px){#mobile-controls{display:flex;}}
   </style></head><body>
   <div id="wrap">
     <canvas id="game" width="256" height="240"></canvas>
@@ -24,7 +34,22 @@
       <span class="hint">J剣 / Kブメ / L弓 / ;爆弾 / Rリセット</span>
     </div>
   </div>
-  
+
+  <div id="mobile-controls">
+    <div class="dpad">
+      <button id="btn-up" class="up" data-key="arrowup">▲</button>
+      <button id="btn-left" class="left" data-key="arrowleft">◀</button>
+      <button id="btn-down" class="down" data-key="arrowdown">▼</button>
+      <button id="btn-right" class="right" data-key="arrowright">▶</button>
+    </div>
+    <div class="actions">
+      <button id="btn-j" data-key="j">J</button>
+      <button id="btn-k" data-key="k">K</button>
+      <button id="btn-l" data-key="l">L</button>
+      <button id="btn-semi" data-key=";">;</button>
+    </div>
+  </div>
+
   <script>
   /* ====== base ====== */
   const cvs=document.getElementById('game'),ctx=cvs.getContext('2d');
@@ -38,6 +63,28 @@
   document.addEventListener('keyup',e=>{keysDown[e.key.toLowerCase()]=false;});
   UI.reset.onclick=e=>{e.preventDefault();init();};
   document.addEventListener('keypress',e=>{if(e.key.toLowerCase()==='r')init();});
+
+  // touch controls
+  function bindTouch(id,key){
+    const el=document.getElementById(id);
+    if(!el) return;
+    const press=e=>{e.preventDefault();keysDown[key]=true;};
+    const release=e=>{e.preventDefault();keysDown[key]=false;};
+    el.addEventListener('touchstart',press,{passive:false});
+    el.addEventListener('touchend',release);
+    el.addEventListener('touchcancel',release);
+    el.addEventListener('mousedown',press);
+    el.addEventListener('mouseup',release);
+    el.addEventListener('mouseleave',release);
+  }
+  bindTouch('btn-up','arrowup');
+  bindTouch('btn-down','arrowdown');
+  bindTouch('btn-left','arrowleft');
+  bindTouch('btn-right','arrowright');
+  bindTouch('btn-j','j');
+  bindTouch('btn-k','k');
+  bindTouch('btn-l','l');
+  bindTouch('btn-semi',';');
   
   /* タイル
      0:床 1:茂み 2:水 3:木 4:橋 5:洞窟入口 6:出口 7:鍵扉 8:鍵


### PR DESCRIPTION
## Summary
- add on-screen D-pad and action buttons for mobile play
- handle touch and mouse events to update game input

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ea599edf88330bf9e48ba6ee93904