### PR TITLE
Improve mobile play area

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,11 +30,10 @@
     .btn{border:1px solid #334155; color:var(--text); background:linear-gradient(180deg,#0f172a,#0b1329); padding:8px 12px; border-radius:12px; cursor:pointer; display:inline-flex; gap:8px; align-items:center; box-shadow:var(--shadow);}
     .btn:hover{border-color:#475569}
 
-    .frame{position:relative; width:100%; max-width:920px; aspect-ratio:16/9; border-radius:20px; overflow:hidden; background:#0a0f1e; box-shadow:var(--shadow); border:1px solid #22314d;}
+    .frame{position:relative; width:100%; max-width:920px; aspect-ratio:32/27; border-radius:20px; overflow:hidden; background:#0a0f1e; box-shadow:var(--shadow); border:1px solid #22314d;}
     canvas{width:100%; height:100%; image-rendering: pixelated; display:block;}
 
     .hud{position:absolute; inset:12px; pointer-events:none;}
-    .hud .tag{pointer-events:auto; position:absolute; top:0; right:0; padding:6px 10px; background:var(--panel); border:1px solid #273244; border-radius:999px; font-size:12px; color:var(--muted);}
 
     .dialog{position:absolute; left:50%; transform:translateX(-50%); bottom:10px; width:min(92%,820px); background:var(--panel); border:1px solid #273244; border-radius:16px; padding:10px 14px; display:none;}
     .dialog.show{display:block;}
@@ -72,9 +71,8 @@
   </header>
 
   <div class="frame">
-    <canvas id="game" width="320" height="180" aria-label="ゲーム画面"></canvas>
+    <canvas id="game" width="320" height="270" aria-label="ゲーム画面"></canvas>
     <div class="hud">
-      <div class="tag">WASD / ⬆︎⬇︎⬅︎➡︎ ＋ J（攻撃）｜モバイルは画面ボタン</div>
       <div id="dialog" class="dialog" role="dialog" aria-live="polite"></div>
     </div>
   </div>
@@ -103,11 +101,11 @@
   const ctx = canvas.getContext('2d');
   const DPR = Math.max(1, Math.min(3, Math.floor(window.devicePixelRatio||1)));
   // Keep internal resolution fixed (pixel-art) while letting CSS scale
-  canvas.width = 320 * DPR; canvas.height = 180 * DPR; ctx.imageSmoothingEnabled = false; ctx.scale(DPR, DPR);
+  canvas.width = 320 * DPR; canvas.height = 270 * DPR; ctx.imageSmoothingEnabled = false; ctx.scale(DPR, DPR);
 
   const TILE = 16; // px
   const VW = 320; // virtual width
-  const VH = 180; // virtual height
+  const VH = 270; // virtual height
 
   // RNG helper
   const rand = (a,b)=>Math.floor(Math.random()*(b-a+1))+a;


### PR DESCRIPTION
## Summary
- Remove on-screen HUD hint text to avoid obstructing controls
- Increase game canvas height by 150% for better vertical view

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b840f18df48330ada2e6880aa13424